### PR TITLE
Edit README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 glulx-assemble
 test_*
+*.exe
 
 # glulx gamefiles and debugging output
 *.ulx

--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
 ﻿# glulx-assemble
 
-glulx-assemble is an assembler for creating [glulx](https://www.eblong.com/zarf/glulx/) program files. It is a re-imagined version of my previous project
-[GGASM](https://github.com/GrenDrake/ggasm) written using C99. The main intent
-behind this program is to serve as a backend that assembles data output by other
-applications, I have tried to design it in such a way that it can be used to
-create programs in pure assembly as well.
+glulx-assemble is an assembler for creating [glulx] program files. It is a re- imagined version of my previous project [GGASM] written using C99. The main intentbehind this program is to serve as a backend that assembles data output by other applications, I have tried to design it in such a way that it can be used to create programs in pure assembly as well.
 
 
 ## License
 
-glulx-assemble is released under the MIT license. Program files created by
-glulx-assemble are not covered by this license and may be licensed as the
-copyright holder desires.
+glulx-assemble is released under the MIT license. Program files created by glulx-assemble are not covered by this license and may be licensed as the copyright holder desires.
 
 
 ## Usage
@@ -22,15 +16,15 @@ A short header will be added after the standard glulx header that includes the 4
 
 Most of these options are intended for debugging the assembler and will not be generally useful.
 
-| Argument           | Description |
-| ------------------ | ----------- |
-| ```-dump-labels``` | Dumps a list of all labels and named constants defined in the program after all assembly was completed. |
-| ```-dump-patches``` | Dumps a list of all the back-patches used by the assembler in creating the final program file. |
-| ```-dump-pretokens``` | Dumps a list of all the tokens in a the main source file before the preprocessing phase begins. |
-| ```-dump-tokens``` | Dumps a list of all the tokens in a program after the preprocessing phase has completed. |
-| ```-dump-debug```  | Dumps assorted debugging information produced during parsing to a file. |
-| ```-no-time```     | Exclude the current time from the default timestamp included in the generated file. |
-| ```-timestamp```   | Replace the default timestamp with a custom timestamp provided after this argument. |
+|      Argument     |                                               Description                                               |
+|-------------------|---------------------------------------------------------------------------------------------------------|
+| `-dump-labels`    | Dumps a list of all labels and named constants defined in the program after all assembly was completed. |
+| `-dump-patches`   | Dumps a list of all the back-patches used by the assembler in creating the final program file.          |
+| `-dump-pretokens` | Dumps a list of all the tokens in a the main source file before the preprocessing phase begins.         |
+| `-dump-tokens`    | Dumps a list of all the tokens in a program after the preprocessing phase has completed.                |
+| `-dump-debug`     | Dumps assorted debugging information produced during parsing to a file.                                 |
+| `-no-time`        | Exclude the current time from the default timestamp included in the generated file.                     |
+| `-timestamp`      | Replace the default timestamp with a custom timestamp provided after this argument.                     |
 
 ```
 glulx-assemble -dump_tokens basic.ga basic.ulx
@@ -39,44 +33,39 @@ glulx-assemble -dump_tokens basic.ga basic.ulx
 
 ## Building glulx-assemble
 
-glulx-assemble is written in standard C99; it should be possible to compile it
-with any compliant compiler. It is packaged using a simple makefile for
-building. There are no external dependencies.
+glulx-assemble is written in standard C99; it should be possible to compile it with any compliant compiler. It is packaged using a simple makefile for building. There are no external dependencies.
 
 
 ## Source Files
 
-Source files are text files with the ".ga" extension. The assembler expects them to be encoded using UTF-8. Some sample source files can be found in the demos directory; [basic.ga](demos/basic.ga) provides a "hello world" style example.
+Source files are text files with the ".ga" extension. The assembler expects them to be encoded using UTF-8. Some sample source files can be found in the demos directory; [basic.ga] provides a "hello world" style example.
 
-A source file is a sequence of one-line statements that the assembler uses to
-create a glulx program file. Each line can begin with a label
-consisting of an identifier followed by a colon (```the_label_name:```). This is followed by the statement for that line.  A source line may also contain a
-comment; comments begin with a semicolon (```;```) and continue until
-the end of the line. All of these elements are optional and a source-line may contain all, some, or none of them. An example of a source line containing all three elements is included below:
+A source file is a sequence of one-line statements that the assembler uses to create a glulx program file. Each line can begin with a label consisting of an identifier followed by a colon (`the_label_name:`). This is followed by the statement for that line.  A source line may also contain a comment; comments begin with a semicolon (`;`) and continue until the end of the line. All of these elements are optional and a source-line may contain all, some, or none of them. An example of a source line containing all three elements is included below:
 
 ```
 start_loop: aloadb a_string #0 #1   ; load next character from string
 ```
 
-There are two kinds of statements: instructions and directives. Instructions make up the majority of most assembly programs and are translated directly into glulx VM instructions. Directives give an instruction to the assembly and may produce output that it written to the glulx file.
+There are two kinds of statements: instructions and directives. Instructions make up the majority of most assembly programs and are translated directly into glulx VM instructions. Directives give an instruction to the assembler and may produce output that is written to the glulx file.
 
 
 
 ### Instructions
 
-An instruction statement consists of an opcode mnemonic followed by zero or more operands. For an index of opcodes and their expected operands, check the [relevant part of the glulx spec](https://www.eblong.com/zarf/glulx/glulx-spec_2.html). There are several types of values that an operand can have, summed up in the table below:
+An instruction statement consists of an opcode mnemonic followed by zero or more operands. For an index of opcodes and their expected operands, check the [relevant part of the glulx spec]. There are several types of values that an operand can have, summed up in the table below:
 
-| Type                   | Sample           | Description |
-| ---------------------- | ---------------- | --- |
-| Integer literal        | ```-42```        | |
-| Hexadecimal literal    | ```$7F```        | |
-| Floating-point literal | ```63.5```       | |
-| Label name             | ```start_loop``` | |
-| Local variable name    | ```index```      | The name of a local variable declared in the last encountered function header. |
-| Local variable index   | ```#2```         | A local variable by position. |
-| Named constant         | ```MAX_LENGTH``` | Created with the ```.define``` directive. |
 
-There is also a special mnemonic ```opcode``` which allows the use of custom opcodes not known to the assembler. The word ```opcode``` may be immediately followed by ```rel``` to indicate that the last operand should be treated as a relative value akin to the jump directives in glulx. Next is the actual number to be used for the opcode followed by all the operands as normal.
+|          Type          |    Sample    |                                  Description                                   |
+|------------------------|--------------|--------------------------------------------------------------------------------|
+| Integer literal        | `-42`        |                                                                                |
+| Hexadecimal literal    | `$7F`        |                                                                                |
+| Floating-point literal | `63.5`       |                                                                                |
+| Label name             | `start_loop` |                                                                                |
+| Local variable name    | `index`      | The name of a local variable declared in the last encountered function header. |
+| Local variable index   | `#2`         | A local variable by position.                                                  |
+| Named constant         | `MAX_LENGTH` | Created with the `.define` directive.                                          |
+
+There is also a special mnemonic `opcode` which allows the use of custom opcodes not known to the assembler. The word `opcode` may be immediately followed by `rel` to indicate that the last operand should be treated as a relative value akin to the jump directives in glulx. Next is the actual number to be used for the opcode followed by all the operands as normal.
 
 ```
 opcode 112 32             ; print a single space character
@@ -87,7 +76,7 @@ opcode rel $20 some_label ; jump to "some_label"
 
 Directives provide instructions to the assembler. Many produce output in the output file, but not all do. All directives begin with a dot to indicate that they are not assembler mnemonics.
 
-Two directives are required in any valid glulx-assemble program: ```.function``` declaring a function named ```start``` to run when the program starts and ```.end_header``` to mark where the header data ends.
+Two directives are required in any valid glulx-assemble program: `.function` declaring a function named `start` to run when the program starts and `.end_header` to mark where the header data ends.
 
 #### General
 
@@ -111,9 +100,10 @@ A few constants are automatically defined. These are *_RAMSTART*, *_EXTSTART*, a
 .extra_memory 512
 ```
 
-**.function**: Adds a function header to the output file. The directive may be immediately followed by ```stk``` to specify that the arguments to this function should be passed on the stack rather than copied into the local variables (see the [glulx spec](https://www.eblong.com/zarf/glulx/glulx-spec_1.html#s.6.2) for details). This is followed by the local variable specification. Locals may be specified by either a positive integer (which will create that many unnamed local variables to be accessed by index) or with a list of local variable names. These styles may not be combined, but if a function has no local variables the specification may be omitted entirely.
+**.function**: Adds a function header to the output file. The directive may be immediately followed by `stk` to specify that the arguments to this function should be passed on the stack rather than copied into the local variables (see the [glulx spec][glulx spec 6.2] for details). This is followed by the local variable specification. Locals may be specified by either a positive integer (which will create that many unnamed local variables to be accessed by index) or with a list of local variable names. These styles may not be combined, but if a function has no local variables the specification may be omitted entirely.
 
-Every glulx program must create at least one function identified by the label ```start```. This will be the entry point of the program. Other functions should generally be identified by appropriate labels as well, though it is not technically required.
+
+Every glulx program must create at least one function identified by the label `start`. This will be the entry point of the program. Other functions should generally be identified by appropriate labels as well, though it is not technically required.
 
 ```
 .function stk 7
@@ -140,7 +130,7 @@ Every glulx program must create at least one function identified by the label ``
 .include "glk.ga"
 ```
 
-**.include_binary**: Includes the raw binary content of another file at the current position of the output file. See the ```.include``` directive above for general details about the include system.
+**.include_binary**: Includes the raw binary content of another file at the current position of the output file. See the `.include` directive above for general details about the include system.
 
 ```
 .include "great_art.png"
@@ -156,7 +146,7 @@ These directives can be given labels or named constants as well as the various n
 .byte 54 76 23 81
 ```
 
-**.cstring**, **.string**: Includes an unencoded, non-unicode string at the current position in the output file. The second version will include the object type byte (0xE0) required for the glulx opcode ```streamstr``` to be able to output the string.
+**.cstring**, **.string**: Includes an unencoded, non-unicode string at the current position in the output file. The second version will include the object type byte (0xE0) required for the glulx opcode `streamstr` to be able to output the string.
 
 ```
 .string "Hello world.\n"
@@ -179,3 +169,11 @@ These directives can be given labels or named constants as well as the various n
 ```
 .zero 54
 ```
+
+[basic.ga]: ./demos/basic.ga "View source file"
+[GGASM]: https://github.com/GrenDrake/ggasm "Visit GGASM repository on GitHub"
+[glulx spec 6.2]: https://www.eblong.com/zarf/glulx/glulx-spec_1.html#s.6.2 "Read Glulx official specs on this topic"
+[glulx]: https://www.eblong.com/zarf/glulx/ "Visit Glulx homepage"
+[relevant part of the glulx spec]: https://www.eblong.com/zarf/glulx/glulx-spec_2.html "Read Glulx official specs on this topic"
+
+<!-- EOF -->


### PR DESCRIPTION
- Fix a couple of typos.
- Convert inline links to reference-style links.
- Change inline-code delimiters to single backticks.
- Join split paragraphs for better diffing on changes and document
  uniformity.
- Visually format tables.